### PR TITLE
[ENG-624] - make sure date params applied to cache key

### DIFF
--- a/EventListener/DashboardSubscriber.php
+++ b/EventListener/DashboardSubscriber.php
@@ -87,9 +87,9 @@ class DashboardSubscriber extends CommonSubscriber
                 }
                 // add date Params as clone params to keep date as unique key for cache
                 // since Core removes date params before generating keys
-                $params    = $widget->getParams();
-                $cloneFrom = isset($params['dateFrom']) ? clone $params['dateFrom'] : new \DateTime('today midnight');
-                $cloneTo   = isset($params['dateTo']) ? clone $params['dateTo'] : new \DateTime('tomorrow midnight - 1 second');
+                $params                  = $widget->getParams();
+                $cloneFrom               = isset($params['dateFrom']) ? clone $params['dateFrom'] : new \DateTime('today midnight');
+                $cloneTo                 = isset($params['dateTo']) ? clone $params['dateTo'] : new \DateTime('tomorrow midnight - 1 second');
                 $params['uniqueDateKey'] = [
                     'fromKey' => $cloneFrom,
                     'toKey'   => $cloneTo,

--- a/EventListener/DashboardSubscriber.php
+++ b/EventListener/DashboardSubscriber.php
@@ -85,6 +85,16 @@ class DashboardSubscriber extends CommonSubscriber
                 if ($defaultCacheTTL < $this->settingsHelper->getCacheTTL()) {
                     $event->setCacheTimeout($this->settingsHelper->getCacheTTL());
                 }
+                // add date Params as clone params to keep date as unique key for cache
+                // since Core removes date params before generating keys
+                $params    = $widget->getParams();
+                $cloneFrom = isset($params['dateFrom']) ? clone $params['dateFrom'] : new \DateTime('today midnight');
+                $cloneTo   = isset($params['dateTo']) ? clone $params['dateTo'] : new \DateTime('tomorrow midnight - 1 second');
+                $params['uniqueDateKey'] = [
+                    'fromKey' => $cloneFrom,
+                    'toKey'   => $cloneTo,
+                ];
+                $widget->setParams($params);
             }
         }
     }


### PR DESCRIPTION
and the to: date is end of day.

- sets a default of today when no date params passed.
- core PR fixes actual cache setting: https://github.com/mautic/mautic/pull/6798 